### PR TITLE
Multiple CentOS 7 Fixes

### DIFF
--- a/homer_installer.sh
+++ b/homer_installer.sh
@@ -476,7 +476,7 @@ case $DIST in
 		  mysql -u "$DB_USER" -p"$DB_PASS" homer_statistic < $SQL_LOCATION/schema_statistic.sql
 
 		  # echo "Creating local DB Node..."
-		  mysql -u "$DB_USER" -p"$DB_PASS" homer_configuration -e "INSERT INTO node VALUES(1,'mysql','homer_data','3306','"$DB_USER"','"$DB_PASS"','sip_capture','node1', 1);"
+		  mysql -u "$DB_USER" -p"$DB_PASS" homer_configuration -e "INSERT INTO node VALUES(default,'mysql','homer_data','3306','"$DB_USER"','"$DB_PASS"','sip_capture','node1', 1);"
 
 		  echo "Homer initial data load complete" > $DATADIR/.homer_initialized
 

--- a/homer_installer.sh
+++ b/homer_installer.sh
@@ -499,9 +499,10 @@ case $DIST in
 		perl -p -i -e "s/lib\/mysql/var\/mysqld/" /opt/rotation.ini
 
 		# Replace values in template
-		perl -p -i -e "s|^(#!substdef \"!HOMER_LISTEN_PORT)!.*|\1!${LISTEN_PORT}!g\"|" $PATH_KAMAILIO_CFG
-		perl -p -i -e "s|^(#!substdef \"!HOMER_DB_USER)!.*|\1!${DB_USER}!g\"|" $PATH_KAMAILIO_CFG
-		perl -p -i -e "s|^(#!substdef \"!HOMER_DB_PASSWORD)!.*|\1!${DB_PASS}!g\"|" $PATH_KAMAILIO_CFG
+		perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_HOMER_CONFIG
+		perl -p -i -e "s/127\.0\.0\.1/$DB_HOST/" $PATH_HOMER_CONFIG
+		perl -p -i -e "s/homer_user/$DB_USER/" $PATH_HOMER_CONFIG
+		perl -p -i -e "s/9060/$LISTEN_PORT/" $PATH_KAMAILIO_CFG
 		
 		# API talks to localhost on CentOS
 		perl -p -i -e "s/127.0.0.1/localhost/" $PATH_HOMER_CONFIG

--- a/homer_installer.sh
+++ b/homer_installer.sh
@@ -401,7 +401,7 @@ case $DIST in
 
 			cp -R /usr/src/homer-ui/* $WEBROOT/
 			cp -R /usr/src/homer-api/api $WEBROOT/
-			chown -R www-data:www-data $WEBROOT/store/
+			chown -R apache:apache $WEBROOT/store/
 			chmod -R 0775 $WEBROOT/store/dashboard
 
 			SQL_LOCATION=/usr/src/homer-api/sql/mysql

--- a/homer_installer.sh
+++ b/homer_installer.sh
@@ -499,10 +499,9 @@ case $DIST in
 		perl -p -i -e "s/lib\/mysql/var\/mysqld/" /opt/rotation.ini
 
 		# Replace values in template
-		perl -p -i -e "s/homer_password/$DB_PASS/" $PATH_HOMER_CONFIG
-		perl -p -i -e "s/127\.0\.0\.1/$DB_HOST/" $PATH_HOMER_CONFIG
-		perl -p -i -e "s/homer_user/$DB_USER/" $PATH_HOMER_CONFIG
-		perl -p -i -e "s/9060/$LISTEN_PORT/" $PATH_KAMAILIO_CFG
+		perl -p -i -e "s|^(#!substdef \"!HOMER_LISTEN_PORT)!.*|\1!${LISTEN_PORT}!g\"|" $PATH_KAMAILIO_CFG
+		perl -p -i -e "s|^(#!substdef \"!HOMER_DB_USER)!.*|\1!${DB_USER}!g\"|" $PATH_KAMAILIO_CFG
+		perl -p -i -e "s|^(#!substdef \"!HOMER_DB_PASSWORD)!.*|\1!${DB_PASS}!g\"|" $PATH_KAMAILIO_CFG
 		
 		# API talks to localhost on CentOS
 		perl -p -i -e "s/127.0.0.1/localhost/" $PATH_HOMER_CONFIG


### PR DESCRIPTION
Addresses the following issues:

[1] Use the "default" keyword for the auto-increment primary key (only within the installer script though)
[2] Properly search/replace the homer db username/password and listen port for kamailio config.
[3] Properly chown'd the html directories (www-data is used in debian based distro's)

These are referenced in the following github issues
#17 
#19 