### PR TITLE
Update GPG key naming from depreciated influxdb.key

### DIFF
--- a/homer_installer.sh
+++ b/homer_installer.sh
@@ -360,7 +360,7 @@ name = InfluxDB Repository - RHEL \$releasever
 baseurl = https://repos.influxdata.com/rhel/\$releasever/\$basearch/stable
 enabled = 1
 gpgcheck = 1
-gpgkey = https://repos.influxdata.com/influxdb.key
+gpgkey = https://repos.influxdata.com/influxdata-archive_compat.key
 EOF
 
     echo "Installing TICK stack ..."


### PR DESCRIPTION
ref # https://repos.influxdata.com/rhel/7/x86_64/

There are currently two GPG keys users can use. The preferred key is influxdata-archive.key. However, if users are running on an older distribution (e.g. CentOS/RHEL 7, Ubuntu 18.04 LTS, or Debian Buster), then the influxdata-archive_compat.key is required for use. This is due to older versions of APT and RPM that do not support subkeys for verification.

influxdata-archive.key: preferred key
influxdata-archive_compat.key: preferred key for older distribution
influxdb.key: deprecated, do not use
influxdb2.key: deprecated, do not use